### PR TITLE
Merge all IAM policies into one, as there is a limit of 10 separate policies per role

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,17 +18,17 @@ This module sets the auth0 var `AWS_SAML_PROVIDER_NAME`, `AWS_ACCOUNT_ID` is als
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.5 |
-| <a name="requirement_auth0"></a> [auth0](#requirement\_auth0) | >=0.34.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >=4.45.0 |
-| <a name="requirement_curl"></a> [curl](#requirement\_curl) | >=1.0.2 |
+| <a name="requirement_auth0"></a> [auth0](#requirement\_auth0) | >= 0.34.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.45.0 |
+| <a name="requirement_curl"></a> [curl](#requirement\_curl) | >= 1.0.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_auth0"></a> [auth0](#provider\_auth0) | >=0.34.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >=4.45.0 |
-| <a name="provider_curl"></a> [curl](#provider\_curl) | >=1.0.2 |
+| <a name="provider_auth0"></a> [auth0](#provider\_auth0) | >= 0.34.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.45.0 |
+| <a name="provider_curl"></a> [curl](#provider\_curl) | >= 1.0.2 |
 
 ## Modules
 
@@ -41,30 +41,13 @@ No modules.
 | [auth0_client.saml](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/client) | resource |
 | [auth0_rule.saml_mappings](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/rule) | resource |
 | [auth0_rule_config.aws_saml_provider_name](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/rule_config) | resource |
-| [aws_iam_policy.cloudwatch_for_github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.iam_for_github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.kms_for_github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.opensearch_for_github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.pi_for_github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.rds_for_github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.s3_for_github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.sns_for_github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.sqs_for_github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.vpc_for_github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.github_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.github_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy_attachment.cloudwatch_for_github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.iam_for_github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.kms_for_github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.opensearch_for_github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.pi_for_github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.rds_for_github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.s3_for_github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.sns_for_github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.sqs_for_github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.vpc_for_github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.github_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_saml_provider.auth0](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_saml_provider) | resource |
 | [aws_iam_account_alias.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_account_alias) | data source |
 | [aws_iam_policy_document.cloudwatch_for_github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.combined](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.federated_role_trust_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.iam_for_github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.kms_for_github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/README.md
+++ b/README.md
@@ -36,7 +36,32 @@ No modules.
 
 ## Resources
 
-
+| Name | Type |
+|------|------|
+| [auth0_client.saml](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/client) | resource |
+| [auth0_rule.saml_mappings](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/rule) | resource |
+| [auth0_rule_config.aws_saml_provider_name](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/rule_config) | resource |
+| [aws_iam_policy.github_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.github_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.github_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_saml_provider.auth0](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_saml_provider) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_account_alias.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_account_alias) | data source |
+| [aws_iam_policy_document.api_gateway_for_github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.cloudwatch_for_github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.cognito_idp_for_github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.combined](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.federated_role_trust_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.iam_for_github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.kms_for_github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.opensearch_for_github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.pi_for_github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.rds_for_github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.s3_for_github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.sns_for_github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.sqs_for_github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.vpc_for_github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [curl_curl.saml_metadata](https://registry.terraform.io/providers/anschoewe/curl/latest/docs/data-sources/curl) | data source |
 
 ## Inputs
 

--- a/api-gateway.tf
+++ b/api-gateway.tf
@@ -11,16 +11,3 @@ data "aws_iam_policy_document" "api_gateway_for_github" {
     }
   }
 }
-
-resource "aws_iam_policy" "api_gateway_for_github" {
-  policy = data.aws_iam_policy_document.api_gateway_for_github.json
-  name   = "api-gateway-for-github"
-  tags = {
-    GithubTeam = "webops"
-  }
-}
-
-resource "aws_iam_role_policy_attachment" "api_gateway_for_github" {
-  role       = aws_iam_role.github_access.name
-  policy_arn = aws_iam_policy.api_gateway_for_github.arn
-}

--- a/aws.tf
+++ b/aws.tf
@@ -38,3 +38,31 @@ resource "aws_iam_role" "github_access" {
   assume_role_policy   = data.aws_iam_policy_document.federated_role_trust_policy.json
   max_session_duration = 10 * 3600
 }
+
+data "aws_iam_policy_document" "combined" {
+  source_policy_documents = [
+    data.aws_iam_policy_document.cloudwatch_for_github.json,
+    data.aws_iam_policy_document.iam_for_github.json,
+    data.aws_iam_policy_document.kms_for_github.json,
+    data.aws_iam_policy_document.opensearch_for_github.json,
+    data.aws_iam_policy_document.pi_for_github.json,
+    data.aws_iam_policy_document.rds_for_github.json,
+    data.aws_iam_policy_document.s3_for_github.json,
+    data.aws_iam_policy_document.sns_for_github.json,
+    data.aws_iam_policy_document.sqs_for_github.json,
+    data.aws_iam_policy_document.vpc_for_github.json,
+  ]
+}
+
+resource "aws_iam_policy" "github_access" {
+  policy = data.aws_iam_policy_document.combined.json
+  name   = "access-via-github"
+  tags = {
+    GithubTeam = "webops"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "github_access" {
+  role       = aws_iam_role.github_access.name
+  policy_arn = aws_iam_policy.github_access.arn
+}

--- a/aws.tf
+++ b/aws.tf
@@ -41,7 +41,9 @@ resource "aws_iam_role" "github_access" {
 
 data "aws_iam_policy_document" "combined" {
   source_policy_documents = [
+    data.aws_iam_policy_document.api_gateway_for_github.json,
     data.aws_iam_policy_document.cloudwatch_for_github.json,
+    data.aws_iam_policy_document.cognito_idp_for_github.json,
     data.aws_iam_policy_document.iam_for_github.json,
     data.aws_iam_policy_document.kms_for_github.json,
     data.aws_iam_policy_document.opensearch_for_github.json,

--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -1,5 +1,4 @@
 data "aws_iam_policy_document" "cloudwatch_for_github" {
-
   statement {
     sid    = "AllowList"
     effect = "Allow"
@@ -24,18 +23,4 @@ data "aws_iam_policy_document" "cloudwatch_for_github" {
       values   = ["*:$${aws:ResourceTag/GithubTeam}:*"]
     }
   }
-
-}
-
-resource "aws_iam_policy" "cloudwatch_for_github" {
-  policy = data.aws_iam_policy_document.cloudwatch_for_github.json
-  name   = "cloudwatch-for-github"
-  tags = {
-    GithubTeam = "webops"
-  }
-}
-
-resource "aws_iam_role_policy_attachment" "cloudwatch_for_github" {
-  role       = aws_iam_role.github_access.name
-  policy_arn = aws_iam_policy.cloudwatch_for_github.arn
 }

--- a/cognito-idp.tf
+++ b/cognito-idp.tf
@@ -28,16 +28,3 @@ data "aws_iam_policy_document" "cognito_idp_for_github" {
     }
   }
 }
-
-resource "aws_iam_policy" "cognito_idp_for_github" {
-  policy = data.aws_iam_policy_document.cognito_idp_for_github.json
-  name   = "cognito-idp-for-github"
-  tags = {
-    GithubTeam = "webops"
-  }
-}
-
-resource "aws_iam_role_policy_attachment" "cognito_idp_for_github" {
-  role       = aws_iam_role.github_access.name
-  policy_arn = aws_iam_policy.cognito_idp_for_github.arn
-}

--- a/iam.tf
+++ b/iam.tf
@@ -1,5 +1,4 @@
 data "aws_iam_policy_document" "iam_for_github" {
-
   statement {
     sid    = "AllowListDescribe"
     effect = "Allow"
@@ -27,18 +26,4 @@ data "aws_iam_policy_document" "iam_for_github" {
       values   = ["*:$${aws:ResourceTag/GithubTeam}:*"]
     }
   }
-
-}
-
-resource "aws_iam_policy" "iam_for_github" {
-  policy = data.aws_iam_policy_document.iam_for_github.json
-  name   = "iam-for-github"
-  tags = {
-    GithubTeam = "webops"
-  }
-}
-
-resource "aws_iam_role_policy_attachment" "iam_for_github" {
-  role       = aws_iam_role.github_access.name
-  policy_arn = aws_iam_policy.iam_for_github.arn
 }

--- a/kms.tf
+++ b/kms.tf
@@ -1,5 +1,4 @@
 data "aws_iam_policy_document" "kms_for_github" {
-
   statement {
     sid    = "AllowRead"
     effect = "Allow"
@@ -37,18 +36,4 @@ data "aws_iam_policy_document" "kms_for_github" {
       values   = ["*:$${aws:ResourceTag/GithubTeam}:*"]
     }
   }
-
-}
-
-resource "aws_iam_policy" "kms_for_github" {
-  policy = data.aws_iam_policy_document.kms_for_github.json
-  name   = "kms-for-github"
-  tags = {
-    GithubTeam = "webops"
-  }
-}
-
-resource "aws_iam_role_policy_attachment" "kms_for_github" {
-  role       = aws_iam_role.github_access.name
-  policy_arn = aws_iam_policy.kms_for_github.arn
 }

--- a/opensearch.tf
+++ b/opensearch.tf
@@ -1,5 +1,4 @@
 data "aws_iam_policy_document" "opensearch_for_github" {
-
   statement {
     sid    = "AllowListDescribe"
     effect = "Allow"
@@ -10,18 +9,4 @@ data "aws_iam_policy_document" "opensearch_for_github" {
     ]
     resources = ["*"]
   }
-
-}
-
-resource "aws_iam_policy" "opensearch_for_github" {
-  policy = data.aws_iam_policy_document.opensearch_for_github.json
-  name   = "opensearch-for-github"
-  tags = {
-    GithubTeam = "webops"
-  }
-}
-
-resource "aws_iam_role_policy_attachment" "opensearch_for_github" {
-  role       = aws_iam_role.github_access.name
-  policy_arn = aws_iam_policy.opensearch_for_github.arn
 }

--- a/pi.tf
+++ b/pi.tf
@@ -1,5 +1,4 @@
 data "aws_iam_policy_document" "pi_for_github" {
-
   statement {
     sid    = "AllowPerformanceInsights"
     effect = "Allow"
@@ -8,18 +7,4 @@ data "aws_iam_policy_document" "pi_for_github" {
     ]
     resources = ["*"]
   }
-
-}
-
-resource "aws_iam_policy" "pi_for_github" {
-  policy = data.aws_iam_policy_document.pi_for_github.json
-  name   = "pi-for-github"
-  tags = {
-    GithubTeam = "webops"
-  }
-}
-
-resource "aws_iam_role_policy_attachment" "pi_for_github" {
-  role       = aws_iam_role.github_access.name
-  policy_arn = aws_iam_policy.pi_for_github.arn
 }

--- a/rds.tf
+++ b/rds.tf
@@ -1,5 +1,4 @@
 data "aws_iam_policy_document" "rds_for_github" {
-
   statement {
     sid    = "AllowListDescribe"
     effect = "Allow"
@@ -28,18 +27,4 @@ data "aws_iam_policy_document" "rds_for_github" {
       values   = ["*:$${aws:ResourceTag/GithubTeam}:*"]
     }
   }
-
-}
-
-resource "aws_iam_policy" "rds_for_github" {
-  policy = data.aws_iam_policy_document.rds_for_github.json
-  name   = "rds-for-github"
-  tags = {
-    GithubTeam = "webops"
-  }
-}
-
-resource "aws_iam_role_policy_attachment" "rds_for_github" {
-  role       = aws_iam_role.github_access.name
-  policy_arn = aws_iam_policy.rds_for_github.arn
 }

--- a/s3.tf
+++ b/s3.tf
@@ -1,5 +1,4 @@
 data "aws_iam_policy_document" "s3_for_github" {
-
   statement {
     sid    = "AllowListDescribe"
     effect = "Allow"
@@ -44,18 +43,4 @@ data "aws_iam_policy_document" "s3_for_github" {
       values   = ["*:$${s3:ExistingObjectTag/GithubTeam}:*"]
     }
   }
-
-}
-
-resource "aws_iam_policy" "s3_for_github" {
-  policy = data.aws_iam_policy_document.s3_for_github.json
-  name   = "s3-for-github"
-  tags = {
-    GithubTeam = "webops"
-  }
-}
-
-resource "aws_iam_role_policy_attachment" "s3_for_github" {
-  role       = aws_iam_role.github_access.name
-  policy_arn = aws_iam_policy.s3_for_github.arn
 }

--- a/sns.tf
+++ b/sns.tf
@@ -1,5 +1,4 @@
 data "aws_iam_policy_document" "sns_for_github" {
-
   statement {
     sid    = "AllowListDescribe"
     effect = "Allow"
@@ -31,18 +30,4 @@ data "aws_iam_policy_document" "sns_for_github" {
       values   = ["*:$${aws:ResourceTag/GithubTeam}:*"]
     }
   }
-
-}
-
-resource "aws_iam_policy" "sns_for_github" {
-  policy = data.aws_iam_policy_document.sns_for_github.json
-  name   = "sns-for-github"
-  tags = {
-    GithubTeam = "webops"
-  }
-}
-
-resource "aws_iam_role_policy_attachment" "sns_for_github" {
-  role       = aws_iam_role.github_access.name
-  policy_arn = aws_iam_policy.sns_for_github.arn
 }

--- a/sqs.tf
+++ b/sqs.tf
@@ -1,5 +1,4 @@
 data "aws_iam_policy_document" "sqs_for_github" {
-
   statement {
     sid    = "AllowListDescribe"
     effect = "Allow"
@@ -30,18 +29,4 @@ data "aws_iam_policy_document" "sqs_for_github" {
       values   = ["*:$${aws:ResourceTag/GithubTeam}:*"]
     }
   }
-
-}
-
-resource "aws_iam_policy" "sqs_for_github" {
-  policy = data.aws_iam_policy_document.sqs_for_github.json
-  name   = "sqs-for-github"
-  tags = {
-    GithubTeam = "webops"
-  }
-}
-
-resource "aws_iam_role_policy_attachment" "sqs_for_github" {
-  role       = aws_iam_role.github_access.name
-  policy_arn = aws_iam_policy.sqs_for_github.arn
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,15 +2,15 @@ terraform {
   required_providers {
     auth0 = {
       source  = "auth0/auth0"
-      version = ">=0.34.0"
+      version = ">= 0.34.0"
     }
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.45.0"
+      version = ">= 4.45.0"
     }
     curl = {
       source  = "anschoewe/curl"
-      version = ">=1.0.2"
+      version = ">= 1.0.2"
     }
   }
   required_version = ">= 1.2.5"

--- a/vpc.tf
+++ b/vpc.tf
@@ -1,5 +1,4 @@
 data "aws_iam_policy_document" "vpc_for_github" {
-
   statement {
     sid    = "AllowListDescribe"
     effect = "Allow"
@@ -25,18 +24,4 @@ data "aws_iam_policy_document" "vpc_for_github" {
     ]
     resources = ["*"]
   }
-
-}
-
-resource "aws_iam_policy" "vpc_for_github" {
-  policy = data.aws_iam_policy_document.vpc_for_github.json
-  name   = "vpc-for-github"
-  tags = {
-    GithubTeam = "webops"
-  }
-}
-
-resource "aws_iam_role_policy_attachment" "vpc_for_github" {
-  role       = aws_iam_role.github_access.name
-  policy_arn = aws_iam_policy.vpc_for_github.arn
 }


### PR DESCRIPTION
There is a limit of 10 attached policies per role, so this merges all policies into one IAM policy and attaches that to the appropriate role.