### PR TITLE
bugfix: filter out non-ministryofjustice teams; and remove all-org-members team

### DIFF
--- a/add-github-teams-to-saml-mappings.js
+++ b/add-github-teams-to-saml-mappings.js
@@ -19,7 +19,7 @@ function(user, context, callback) {
     };
     request(teams_req, function (err, resp, body) {
       if (resp.statusCode !== 200) {
-        return callback(new Error('Error retrieving teams from Github: ' + body || err));
+        return callback(new Error('Error retrieving teams from GitHub: ' + body || err));
       }
       user.awsRoleSession = user.nickname;
       user.awsTagKeys = ['GithubTeam'];
@@ -27,9 +27,14 @@ function(user, context, callback) {
         if (team.organization.login === "ministryofjustice") {
           return team.slug;
         }
+      }).filter(function(team) {
+        if(team === "all-org-members") {
+          return false;
+        }
+        return team;
       });
       user.GithubTeam = ":" + git_teams.join(":") + ":";
-			user.awsRole = rolePrefix + ':role/' + role + "," + samlIdP;
+      user.awsRole = rolePrefix + ':role/' + role + "," + samlIdP;
       context.samlConfiguration.mappings = {
           'https://aws.amazon.com/SAML/Attributes/Role': 'awsRole',
           'https://aws.amazon.com/SAML/Attributes/RoleSessionName': 'awsRoleSession',


### PR DESCRIPTION
As part of some investigation into ministryofjustice/cloud-platform#4455 with @sj-williams, we came across a [value limit of 256 characters for session tags](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithSAML.html) in the AWS documentation.

To help alleviate that for those _near_ the limit, this PR does two things:

- removes the `all-org-members` team from the GitHub teams passed to the session value, saving 16 characters (`all-org-members` plus the separator `:`
- filters out null values from non-`ministryofjustice` teams to correctly represent the length of `ministryofjustice` teams in the `git_teams` array, saving useless double colon separators (`::`)