### PR TITLE
Add new DLQ Redrive permissions to SQS policy

### DIFF
--- a/sqs.tf
+++ b/sqs.tf
@@ -16,11 +16,14 @@ data "aws_iam_policy_document" "sqs_for_github" {
     sid    = "AllowSQSSendRecvOwn"
     effect = "Allow"
     actions = [
+      "sqs:CancelMessageMoveTask",
       "sqs:ChangeMessageVisibility",
       "sqs:DeleteMessage",
+      "sqs:ListMessageMoveTasks",
       "sqs:ReceiveMessage",
       "sqs:SendMessage",
-      "sqs:PurgeQueue",
+      "sqs:StartMessageMoveTask",
+      "sqs:PurgeQueue"
     ]
     resources = ["*"]
     condition {


### PR DESCRIPTION
This PR adds permissions to perform DLQ redrives using the new IAM action names - these used to be covered by Send/ReceiveMessage. The new permissions and CloudTrail events take effect on 31st August 2023.

https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues-cloudtrail.html