### PR TITLE
Add wafv2 and SMS permissions to cognito pool

### DIFF
--- a/cognito-idp.tf
+++ b/cognito-idp.tf
@@ -3,7 +3,8 @@ data "aws_iam_policy_document" "cognito_idp_for_github" {
     sid    = "AllowCognitoList"
     effect = "Allow"
     actions = [
-      "cognito-idp:ListUserPools"
+      "cognito-idp:ListUserPools",
+      "cognito-idp:DescribeUserPoolDomain"
     ]
     resources = ["*"]
   }
@@ -14,7 +15,9 @@ data "aws_iam_policy_document" "cognito_idp_for_github" {
     actions = [
       "cognito-idp:List*",
       "cognito-idp:Describe*",
-      "cognito-idp:Get*"
+      "cognito-idp:Get*",
+      "wafv2:GetWebACLForResource",
+      "SNS:GetSMSSandboxAccountStatus"
     ]
     resources = [
       "arn:aws:cognito-idp:*:${data.aws_caller_identity.current.account_id}:userpool/*",


### PR DESCRIPTION
User reported they are seeing errors when clicking "App Integration" tab of cognito -> user pool. Adding permissions specific to resource and DescribeUserPoolDomain for *

Slack discussion: https://mojdt.slack.com/archives/C57UPMZLY/p1705500288994079