### PR TITLE
Fixing document typo

### DIFF
--- a/ecr.tf
+++ b/ecr.tf
@@ -3,7 +3,7 @@ data "aws_iam_policy_document" "ecr_for_github" {
     sid    = "AllowECRListDescribe"
     effect = "Allow"
     actions = [
-      "ecr:DescribeRegistry"
+      "ecr:DescribeRepositories"
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
Fixing from `DescribeRegistry` to `DescribeRepositories` for all permission. 