### PR TITLE
Backups read only

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ No modules.
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_account_alias.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_account_alias) | data source |
 | [aws_iam_policy_document.api_gateway_for_github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.backups_for_github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.bedrock_for_github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cloudwatch_for_github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cognito_idp_for_github](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/aws.tf
+++ b/aws.tf
@@ -63,6 +63,7 @@ data "aws_iam_policy_document" "combined_2" {
     data.aws_iam_policy_document.bedrock_for_github.json,
     data.aws_iam_policy_document.mq_for_github.json,
     data.aws_iam_policy_document.ecr_for_github.json,
+    data.aws_iam_policy_document.backups_for_github.json,
   ]
 }
 

--- a/backups.tf
+++ b/backups.tf
@@ -4,7 +4,10 @@ data "aws_iam_policy_document" "backups_for_github" {
     effect = "Allow"
     actions = [
       "backup:ListBackupVaults",
-      "backup:ListBackupPlans"
+      "backup:ListBackupPlans",
+      "backup:ListBackupJobs",
+      "backup:ListRestoreJobs",
+      "backup:ListProtectedResources"
     ]
     resources = ["*"]
   }

--- a/backups.tf
+++ b/backups.tf
@@ -1,6 +1,6 @@
 data "aws_iam_policy_document" "backups_for_github" {
   statement {
-    sid    = "AllowCognitoList"
+    sid    = "AllowBackupsList"
     effect = "Allow"
     actions = [
       "backup:ListBackupVaults",
@@ -13,7 +13,7 @@ data "aws_iam_policy_document" "backups_for_github" {
   }
 
   statement {
-    sid    = "AllowCognitoGetOwn"
+    sid    = "AllowBackupsGetOwn"
     effect = "Allow"
     actions = [
       "backup:Describe*",

--- a/backups.tf
+++ b/backups.tf
@@ -20,10 +20,7 @@ data "aws_iam_policy_document" "backups_for_github" {
       "backup:Get*",
       "backup:List*"
     ]
-    resources = [
-      "arn:aws:cognito-idp:*:${data.aws_caller_identity.current.account_id}:userpool/*",
-      "arn:aws:wafv2:*:${data.aws_caller_identity.current.account_id}:*/webacl/*/*"
-    ]
+    resources = ["*"]
 
     condition {
       test     = "StringLike"

--- a/backups.tf
+++ b/backups.tf
@@ -1,0 +1,31 @@
+data "aws_iam_policy_document" "backups_for_github" {
+  statement {
+    sid    = "AllowCognitoList"
+    effect = "Allow"
+    actions = [
+      "backup:ListBackupVaults",
+      "backup:ListBackupPlans"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "AllowCognitoGetOwn"
+    effect = "Allow"
+    actions = [
+      "backup:Describe*",
+      "backup:Get*",
+      "backup:List*"
+    ]
+    resources = [
+      "arn:aws:cognito-idp:*:${data.aws_caller_identity.current.account_id}:userpool/*",
+      "arn:aws:wafv2:*:${data.aws_caller_identity.current.account_id}:*/webacl/*/*"
+    ]
+
+    condition {
+      test     = "StringLike"
+      variable = "aws:PrincipalTag/GithubTeam"
+      values   = ["*:$${aws:ResourceTag/GithubTeam}:*"]
+    }
+  }
+}


### PR DESCRIPTION
This will grant the ability to list the backup vaults, jobs, and protected resources and be able to get more details for the ones within the users namespace.

This relates to the S3 buckets AWS Backup restore process issue [#6039](https://github.com/ministryofjustice/cloud-platform/issues/6039)