### PR TITLE
feat: 🎸 add permissions for viewing rds instance logs

### DIFF
--- a/rds.tf
+++ b/rds.tf
@@ -14,6 +14,7 @@ data "aws_iam_policy_document" "rds_for_github" {
     effect = "Allow"
     actions = [
       "rds:CreateDBSnapshot",
+      "rds:DescribeDBLogFiles",
       "rds:DownloadCompleteDBLogFile",
       "rds:DownloadDBLogFilePortion",
       "rds:ModifyDBInstance",


### PR DESCRIPTION
its helpful for users to be able to view or tail the actual contents of their instance log files. this pr should sort that.